### PR TITLE
Add rgb_image field to Person.msg

### DIFF
--- a/mcr_perception_msgs/msg/Person.msg
+++ b/mcr_perception_msgs/msg/Person.msg
@@ -6,6 +6,8 @@ geometry_msgs/PoseStamped pose	# real pose of a detected person
 
 geometry_msgs/PoseStamped safe_pose		# safety pose for a detected person (to approach by base)
 
+sensor_msgs/Image rgb_image                     # image cropped to the bounding box of the detected person
+
 float32 height					# measured height of the person
 
 float32 width					# measured width of the person 


### PR DESCRIPTION
This is for keeping an image of the detected person. It's needed for the Robocup 2019 "Find my mates" scenario.