### PR TITLE
Make plane coefficients public

### DIFF
--- a/mcr_scene_segmentation/common/include/mcr_scene_segmentation/scene_segmentation.h
+++ b/mcr_scene_segmentation/common/include/mcr_scene_segmentation/scene_segmentation.h
@@ -34,8 +34,10 @@ public:
     virtual ~SceneSegmentation();
 
     PointCloud::Ptr segment_scene(const PointCloud::ConstPtr &cloud, std::vector<PointCloud::Ptr> &clusters,
-    std::vector<mas_perception_libs::BoundingBox> &boxes, double &workspace_height);
-    PointCloud::Ptr findPlane(const PointCloud::ConstPtr &cloud, PointCloud::Ptr &hull, double &workspace_height);
+                                  std::vector<mas_perception_libs::BoundingBox> &boxes, 
+                                  Eigen::Vector4f &model_coefficients, double &workspace_height);
+    PointCloud::Ptr findPlane(const PointCloud::ConstPtr &cloud, PointCloud::Ptr &hull,
+                              Eigen::Vector4f &coefficients, double &workspace_height);
 
     void setCloudFilterParams(const mpl::CloudFilterParams&);
     void setPlaneSegmenterParams(const mpl::SacPlaneSegmenterParams&);
@@ -44,9 +46,7 @@ public:
     void setClusterParams(double cluster_tolerance, int cluster_min_size, int cluster_max_size,
                           double cluster_min_height, double cluster_max_height,  double max_length,
                           double cluster_min_distance_to_polygon);
-public:
-    // Make model coefficients public for 3d bbox from rgb bbox propossal
-    Eigen::Vector4f coefficients_;
+
 };
 
 #endif  // MCR_SCENE_SEGMENTATION_SCENE_SEGMENTATION_H

--- a/mcr_scene_segmentation/common/include/mcr_scene_segmentation/scene_segmentation.h
+++ b/mcr_scene_segmentation/common/include/mcr_scene_segmentation/scene_segmentation.h
@@ -35,8 +35,7 @@ public:
 
     PointCloud::Ptr segment_scene(const PointCloud::ConstPtr &cloud, std::vector<PointCloud::Ptr> &clusters,
     std::vector<mas_perception_libs::BoundingBox> &boxes, double &workspace_height);
-    PointCloud::Ptr findPlane(const PointCloud::ConstPtr &cloud, PointCloud::Ptr &hull,
-                              Eigen::Vector4f &coefficients, double &workspace_height);
+    PointCloud::Ptr findPlane(const PointCloud::ConstPtr &cloud, PointCloud::Ptr &hull, double &workspace_height);
 
     void setCloudFilterParams(const mpl::CloudFilterParams&);
     void setPlaneSegmenterParams(const mpl::SacPlaneSegmenterParams&);
@@ -45,6 +44,9 @@ public:
     void setClusterParams(double cluster_tolerance, int cluster_min_size, int cluster_max_size,
                           double cluster_min_height, double cluster_max_height,  double max_length,
                           double cluster_min_distance_to_polygon);
+public:
+    // Make model coefficients public for 3d bbox from rgb bbox propossal
+    Eigen::Vector4f coefficients_;
 };
 
 #endif  // MCR_SCENE_SEGMENTATION_SCENE_SEGMENTATION_H

--- a/mcr_scene_segmentation/common/src/scene_segmentation.cpp
+++ b/mcr_scene_segmentation/common/src/scene_segmentation.cpp
@@ -22,8 +22,8 @@ PointCloud::Ptr SceneSegmentation::segment_scene(const PointCloud::ConstPtr &clo
         std::vector<PointCloud::Ptr> &clusters, std::vector<BoundingBox> &boxes, double &workspace_height)
 {
     PointCloud::Ptr hull;
-    Eigen::Vector4f coefficients;
-    PointCloud::Ptr filtered = findPlane(cloud, hull, coefficients, workspace_height);
+    //Eigen::Vector4f coefficients;
+    PointCloud::Ptr filtered = findPlane(cloud, hull, workspace_height);
 
     pcl::PointIndices::Ptr segmented_cloud_inliers = boost::make_shared<pcl::PointIndices>();
     extract_polygonal_prism.setInputPlanarHull(hull);
@@ -41,7 +41,7 @@ PointCloud::Ptr SceneSegmentation::segment_scene(const PointCloud::ConstPtr &clo
         PointCloud::Ptr cluster = boost::make_shared<PointCloud>();
         pcl::copyPointCloud(*cloud, cluster_indices, *cluster);
         clusters.push_back(cluster);
-        Eigen::Vector3f normal(coefficients[0], coefficients[1], coefficients[2]);
+        Eigen::Vector3f normal(coefficients_[0], coefficients_[1], coefficients_[2]);
         BoundingBox box = BoundingBox::create(cluster->points, normal);
         boxes.push_back(box);
     }
@@ -49,13 +49,13 @@ PointCloud::Ptr SceneSegmentation::segment_scene(const PointCloud::ConstPtr &clo
 }
 
 PointCloud::Ptr SceneSegmentation::findPlane(const PointCloud::ConstPtr &cloud, PointCloud::Ptr &hull,
-                                             Eigen::Vector4f &coefficients, double &workspace_height)
+                                             double &workspace_height)
 {
     PointCloud::Ptr filtered = cloud_filter.filterCloud(cloud);
     try
     {
         mpl::PlaneModel planeModel = plane_segmenter.findPlane(filtered);
-        coefficients = planeModel.mCoefficients;
+        coefficients_ = planeModel.mCoefficients;
         hull = planeModel.mHullPointsPtr;
         workspace_height = planeModel.mCenter.z;
     }

--- a/mcr_scene_segmentation/common/src/scene_segmentation.cpp
+++ b/mcr_scene_segmentation/common/src/scene_segmentation.cpp
@@ -23,9 +23,7 @@ PointCloud::Ptr SceneSegmentation::segment_scene(const PointCloud::ConstPtr &clo
         Eigen::Vector4f &model_coefficients, double &workspace_height)
 {
     PointCloud::Ptr hull;
-    Eigen::Vector4f coefficients;
-    PointCloud::Ptr filtered = findPlane(cloud, hull, coefficients, workspace_height);
-    model_coefficients = coefficients;
+    PointCloud::Ptr filtered = findPlane(cloud, hull, model_coefficients, workspace_height);
 
     pcl::PointIndices::Ptr segmented_cloud_inliers = boost::make_shared<pcl::PointIndices>();
     extract_polygonal_prism.setInputPlanarHull(hull);
@@ -43,7 +41,7 @@ PointCloud::Ptr SceneSegmentation::segment_scene(const PointCloud::ConstPtr &clo
         PointCloud::Ptr cluster = boost::make_shared<PointCloud>();
         pcl::copyPointCloud(*cloud, cluster_indices, *cluster);
         clusters.push_back(cluster);
-        Eigen::Vector3f normal(coefficients[0], coefficients[1], coefficients[2]);
+        Eigen::Vector3f normal(model_coefficients[0], model_coefficients[1], model_coefficients[2]);
         BoundingBox box = BoundingBox::create(cluster->points, normal);
         boxes.push_back(box);
     }
@@ -51,13 +49,13 @@ PointCloud::Ptr SceneSegmentation::segment_scene(const PointCloud::ConstPtr &clo
 }
 
 PointCloud::Ptr SceneSegmentation::findPlane(const PointCloud::ConstPtr &cloud, PointCloud::Ptr &hull, 
-                                            Eigen::Vector4f &coefficients, double &workspace_height)
+                                            Eigen::Vector4f &model_coefficients, double &workspace_height)
 {
     PointCloud::Ptr filtered = cloud_filter.filterCloud(cloud);
     try
     {
         mpl::PlaneModel planeModel = plane_segmenter.findPlane(filtered);
-        coefficients = planeModel.mCoefficients;
+        model_coefficients = planeModel.mCoefficients;
         hull = planeModel.mHullPointsPtr;
         workspace_height = planeModel.mCenter.z;
     }

--- a/mcr_scene_segmentation/common/src/scene_segmentation.cpp
+++ b/mcr_scene_segmentation/common/src/scene_segmentation.cpp
@@ -19,11 +19,13 @@ SceneSegmentation::SceneSegmentation()
 SceneSegmentation::~SceneSegmentation() = default;
 
 PointCloud::Ptr SceneSegmentation::segment_scene(const PointCloud::ConstPtr &cloud,
-        std::vector<PointCloud::Ptr> &clusters, std::vector<BoundingBox> &boxes, double &workspace_height)
+        std::vector<PointCloud::Ptr> &clusters, std::vector<BoundingBox> &boxes, 
+        Eigen::Vector4f &model_coefficients, double &workspace_height)
 {
     PointCloud::Ptr hull;
-    //Eigen::Vector4f coefficients;
-    PointCloud::Ptr filtered = findPlane(cloud, hull, workspace_height);
+    Eigen::Vector4f coefficients;
+    PointCloud::Ptr filtered = findPlane(cloud, hull, coefficients, workspace_height);
+    model_coefficients = coefficients;
 
     pcl::PointIndices::Ptr segmented_cloud_inliers = boost::make_shared<pcl::PointIndices>();
     extract_polygonal_prism.setInputPlanarHull(hull);
@@ -41,21 +43,21 @@ PointCloud::Ptr SceneSegmentation::segment_scene(const PointCloud::ConstPtr &clo
         PointCloud::Ptr cluster = boost::make_shared<PointCloud>();
         pcl::copyPointCloud(*cloud, cluster_indices, *cluster);
         clusters.push_back(cluster);
-        Eigen::Vector3f normal(coefficients_[0], coefficients_[1], coefficients_[2]);
+        Eigen::Vector3f normal(coefficients[0], coefficients[1], coefficients[2]);
         BoundingBox box = BoundingBox::create(cluster->points, normal);
         boxes.push_back(box);
     }
     return filtered;
 }
 
-PointCloud::Ptr SceneSegmentation::findPlane(const PointCloud::ConstPtr &cloud, PointCloud::Ptr &hull,
-                                             double &workspace_height)
+PointCloud::Ptr SceneSegmentation::findPlane(const PointCloud::ConstPtr &cloud, PointCloud::Ptr &hull, 
+                                            Eigen::Vector4f &coefficients, double &workspace_height)
 {
     PointCloud::Ptr filtered = cloud_filter.filterCloud(cloud);
     try
     {
         mpl::PlaneModel planeModel = plane_segmenter.findPlane(filtered);
-        coefficients_ = planeModel.mCoefficients;
+        coefficients = planeModel.mCoefficients;
         hull = planeModel.mHullPointsPtr;
         workspace_height = planeModel.mCenter.z;
     }

--- a/mcr_scene_segmentation/ros/src/scene_segmentation_node.cpp
+++ b/mcr_scene_segmentation/ros/src/scene_segmentation_node.cpp
@@ -127,7 +127,8 @@ void SceneSegmentationNode::segment()
     std::vector<PointCloud::Ptr> clusters;
     std::vector<BoundingBox> boxes;
     double workspace_height;
-    PointCloud::Ptr debug = scene_segmentation_.segment_scene(cloud, clusters, boxes, workspace_height);
+    Eigen::Vector4f model_coefficients;
+    PointCloud::Ptr debug = scene_segmentation_.segment_scene(cloud, clusters, boxes, model_coefficients, workspace_height);
     debug->header.frame_id = cloud->header.frame_id;
     std_msgs::Float64 workspace_height_msg;
     workspace_height_msg.data = workspace_height;
@@ -262,8 +263,8 @@ void SceneSegmentationNode::findPlane()
 
     double workspace_height = 0.0;
     PointCloud::Ptr hull;
-    //Eigen::Vector4f coefficients;
-    PointCloud::Ptr debug = scene_segmentation_.findPlane(cloud, hull, workspace_height);
+    Eigen::Vector4f model_coefficients;
+    PointCloud::Ptr debug = scene_segmentation_.findPlane(cloud, hull, model_coefficients, workspace_height);
     debug->header.frame_id = cloud->header.frame_id;
     std_msgs::Float64 workspace_height_msg;
     workspace_height_msg.data = workspace_height;

--- a/mcr_scene_segmentation/ros/src/scene_segmentation_node.cpp
+++ b/mcr_scene_segmentation/ros/src/scene_segmentation_node.cpp
@@ -262,8 +262,8 @@ void SceneSegmentationNode::findPlane()
 
     double workspace_height = 0.0;
     PointCloud::Ptr hull;
-    Eigen::Vector4f coefficients;
-    PointCloud::Ptr debug = scene_segmentation_.findPlane(cloud, hull, coefficients, workspace_height);
+    //Eigen::Vector4f coefficients;
+    PointCloud::Ptr debug = scene_segmentation_.findPlane(cloud, hull, workspace_height);
     debug->header.frame_id = cloud->header.frame_id;
     std_msgs::Float64 workspace_height_msg;
     workspace_height_msg.data = workspace_height;


### PR DESCRIPTION
We need model coefficient information to fit 3d bounding box given 2d bbox proposal. The bounding box calculation is defined here: [bounding_box](https://github.com/b-it-bots/mas_perception_libs/blob/055a1e44984dc829fc4b1ea4e03b81eb072e32f7/common/src/bounding_box.cpp#L24). <br>
changes:
* Make model coefficients public
* Remove coefficient reference from findPlane function as it's public already.
<br>
Other solution to avoid public variable <br>
* Passing coefficient reference to segment_scene()

@minhnh  @sthoduka 