### PR TITLE
[WIP] Fix melodic build error in leg_detection_node

### DIFF
--- a/mcr_leg_detection/ros/src/leg_detection_node.cpp
+++ b/mcr_leg_detection/ros/src/leg_detection_node.cpp
@@ -253,7 +253,7 @@ public:
 	
         if (g_argc > 1)
         {
-            forest->load(g_argv[1]);
+            forest->load<cv::ml::RTrees>(g_argv[1]);
             feat_count_ = forest->getActiveVarCount();
             printf("Loaded forest with %d features: %s\n", feat_count_, g_argv[1]);
         }


### PR DESCRIPTION
Fixes build errors in Ubuntu Bionic. The last CI build for the melodic branch used the `bitbots/bitbots-common:kinetic` image as base and hence the build issues related to melodic are not visible.

@argenos is there a plan to create base images for the melodic branch? From [here](https://github.com/b-it-bots/mas_common_robotics/blob/93c35a421f8d162833b633e339b2b8a6f09b0e3d/Dockerfile#L1) I see that we are using kinetic base images even on the melodic branch.

## Changelog
* Use explicit template instantiation to fix the build error in mcr_leg_detection

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [x] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [x] I have updated the documentation accordingly.

<!-- Click on the preview button to make sure everything is correctly formatted -->
